### PR TITLE
Supports API mode by allowing nonce to be passed as a parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Rails.application.config.middleware.use OmniAuth::Builder do
              scope: 'email name',
              team_id: ENV['TEAM_ID'],
              key_id: ENV['KEY_ID'],
-             pem: ENV['PRIVATE_KEY']
+             pem: ENV['PRIVATE_KEY'],
+             nonce: :session # :session, :param, or :ignore. Set this to ":param" in an API only backend
            }
 end
 ```

--- a/lib/omniauth/strategies/apple.rb
+++ b/lib/omniauth/strategies/apple.rb
@@ -90,16 +90,10 @@ module OmniAuth
       end
 
       def verify_nonce!(id_token)
-        case options.nonce
-        when :session
-          invalid_claim! :nonce unless id_token[:nonce] && id_token[:nonce] == stored_nonce
-        when :param
-          invalid_claim! :nonce unless id_token[:nonce] && id_token[:nonce] == stored_nonce
-        when :ignore
-          true
-        else
-          raise ArgumentError, "Invalid nonce option: #{options.nonce}. Must be :session, :param, or :ignore"
-        end
+        return true if options.nonce == :ignore
+        raise ArgumentError, "Invalid nonce option: #{options.nonce}. Must be :session, :param, or :ignore" unless [:session, :param].include?(options.nonce)
+
+        invalid_claim! :nonce unless id_token[:nonce] && id_token[:nonce] == stored_nonce
       end
 
       def id_info

--- a/lib/omniauth/strategies/apple.rb
+++ b/lib/omniauth/strategies/apple.rb
@@ -20,7 +20,7 @@ module OmniAuth
              scope: 'email name'
       option :authorized_client_ids, []
 
-      option :nonce, :session # :session, :local, or :ignore
+      option :nonce, :session # :session, :param, or :ignore
 
       uid { id_info[:sub] }
 


### PR DESCRIPTION
inspired by https://github.com/nhosoya/omniauth-apple/pull/111 but without dependency on Rails/ActionDispatch cookies feature (i.e. works with any Rack app).